### PR TITLE
Provide option to overwrite existing archived files when archiving

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -2,6 +2,7 @@ import {
 	App,
 	Editor,
 	MarkdownView,
+	Modal,
 	normalizePath,
 	Notice,
 	Plugin,
@@ -142,6 +143,41 @@ export default class SimpleArchiver extends Plugin {
 
 	async saveSettings() {
 		await this.saveData(this.settings);
+	}
+}
+
+class SimpleArchiverPromptModal extends Modal {
+	constructor(
+		app: App,
+		title: string,
+		message: string,
+		yesButtonText: string,
+		noButtonText: string,
+		callback: () => Promise<void>,
+		cancelCallback: () => Promise<void>
+	) {
+		super(app);
+
+		this.setTitle(title);
+
+		this.setContent(message);
+
+		new Setting(this.contentEl)
+			.addButton((btn) =>
+				btn
+					.setButtonText(yesButtonText)
+					.setWarning()
+					.onClick(() => {
+						callback();
+						this.close();
+					})
+			)
+			.addButton((btn) =>
+				btn.setButtonText(noButtonText).onClick(() => {
+					cancelCallback();
+					this.close();
+				})
+			);
 	}
 }
 


### PR DESCRIPTION
When attempting to archive a folder or note when an item already exists in the same path in the archive, the user is prompted to either overwrite the already archived item or cancel the archive operation. If the user chooses to overwrite, the overwritten item is either moved to the user's trash or permanently deleted based on their Obsidian configuration.

Resolves #4 