### PR TITLE
Fix leading zero preservation in unarchive operation

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -268,12 +268,12 @@ export default class SimpleArchiver extends Plugin {
 				this.app.vault.getFolderByPath(originalParentPath);
 
 			if (originalFolder == null) {
-				await this.app.vault.createFolder(originalParentPath);
+				await this.app.vault.createFolder(normalizePath(originalParentPath));
 			}
 		}
 
 		try {
-			await this.app.fileManager.renameFile(file, originalPath);
+			await this.app.fileManager.renameFile(file, normalizePath(originalPath));
 			return {
 				success: true,
 				message: `${file.name} unarchived successfully`,


### PR DESCRIPTION
## Summary

Fixes #15 - Resolves issue where unarchiving files from folders with leading zeros (e.g., 00-inbox) incorrectly stripped the leading zero, causing files to be restored to wrong locations (e.g., 0-inbox).

## Root Cause

The unarchive operation was not normalizing paths before passing them to Obsidian's file management APIs, unlike the archive operation which consistently normalized all paths. This inconsistency caused Obsidian's internal path processing to handle paths differently, stripping leading zeros.

## Changes

File: main.ts in moveFileOutOfArchive() method

1. Line 271: Added normalizePath() to folder creation
   ```typescript
   await this.app.vault.createFolder(normalizePath(originalParentPath));
   ```

2. Line 276: Added normalizePath() to file rename operation
   ```typescript
   await this.app.fileManager.renameFile(file, normalizePath(originalPath));
   ```

This ensures consistent path handling between archive and unarchive operations.

## Testing

All scenarios tested successfully on both Windows 11 and macOS:

- Single leading zero (00-inbox, 01-projects)
- Multiple leading zeros (000-archive)
- Single zero folders (0-temp)
- Just "0" as folder name
- Deeply nested numeric folders (00-inbox/01-sub/02-deep)
- Regular folders (regression test - no leading zeros)
- Multiple files in same folder

## Impact

- Minimal code change: Only 2 lines modified
- No breaking changes: All existing functionality preserved
- Consistent behavior: Archive and unarchive now handle paths identically